### PR TITLE
Made it a typed library.

### DIFF
--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -3,7 +3,7 @@
 from pytest import fixture, raises
 import pytest
 
-from my_model.user_scoped_models import APIClient  # type:ignore
+from my_model.user_scoped_models import APIClient
 
 
 @fixture

--- a/tests/test_api_scope.py
+++ b/tests/test_api_scope.py
@@ -2,7 +2,7 @@
 # pylint: disable=redefined-outer-name
 from pytest import fixture
 
-from my_model.global_models import APIScope  # type:ignore
+from my_model.global_models import APIScope
 
 
 @fixture

--- a/tests/test_api_token.py
+++ b/tests/test_api_token.py
@@ -3,7 +3,7 @@
 from pytest import fixture, raises
 import pytest
 
-from my_model.user_scoped_models import APIToken  # type:ignore
+from my_model.user_scoped_models import APIToken
 
 
 @fixture

--- a/tests/test_base_model.py
+++ b/tests/test_base_model.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from my_model.my_model import MyModel  # type:ignore
+from my_model.my_model import MyModel
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -3,7 +3,7 @@
 from pytest import fixture, raises
 import pytest
 
-from my_model.user_scoped_models import Tag  # type:ignore
+from my_model.user_scoped_models import Tag
 
 
 @fixture

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -6,7 +6,7 @@ from pyotp import TOTP
 from pytest import fixture, raises
 import pytest
 
-from my_model.user_scoped_models import User  # type:ignore
+from my_model.user_scoped_models import User
 
 
 @fixture


### PR DESCRIPTION
Removed all the `type:ignore` hints in the files that caused `mypy` to fail and created a `py.typed` file to mark this library as typed.

Fixes #60